### PR TITLE
Add selected label counts for closed PRs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'activesupport', "~> 5.0",   :require => false
+gem 'more_core_extensions',      :require => false
 gem 'octokit',       "~> 4.3.0", :require => false

--- a/prs_per_repo.rb
+++ b/prs_per_repo.rb
@@ -25,18 +25,20 @@ def repos_to_track
   stats.project_names_from_org("ManageIQ").to_a + ["Ansible/ansible_tower_client_ruby"]
 end
 
-
+labels  = ["bug", "enhancement", "developer", "documentation", "performance", "refactoring", "technical debt", "test", ]
 results = []
 repos_to_track.sort.each do |repo|
   puts "Collecting pull_requests for: #{repo}"
   prs                = stats.pull_requests(repo, :state => :all, :since => sprint_range.first.iso8601)
   closed             = prs.select { |pr| sprint_range.include?(pr.closed_at) }
+  closed_labels_hash = closed.each_with_object([]) { |pr, arr| pr.labels.each { |label| arr << label.name } }.element_counts
   opened             = prs.select { |pr| sprint_range.include?(pr.created_at) }
   prs_remaining_open = stats.raw_pull_requests(repo, :state => :open).length
-  results << "#{repo},#{opened.length},#{closed.length},#{prs_remaining_open}"
+  labels_string      = closed_labels_hash.values_at(*labels).collect(&:to_i).join(",")
+  results << "#{repo},#{opened.length},#{closed.length},#{labels_string},#{prs_remaining_open}"
 end
 
 File.open('prs_per_repo.csv', 'w') do |f|
-  f.puts "Pull Requests from: #{sprint_range.first} to: #{sprint_range.last}.  repo,#opened,#closed,#remaining_open"
+  f.puts "Pull Requests from: #{sprint_range.first} to: #{sprint_range.last}.  repo,#opened,#closed,#{labels.collect { |l| "closed_#{l}" }.join(",")},#remaining_open"
   results.each { |line| f.puts(line) }
 end


### PR DESCRIPTION
```
$ cat prs_per_repo.csv 
Pull Requests from: 2017-05-01 00:00:00 UTC to: 2017-05-15 00:00:00 UTC.  repo,#opened,#closed,closed_bug,closed_enhancement,closed_developer,closed_documentation,closed_performance,closed_refactoring,closed_technical debt,closed_test,#remaining_open
Ansible/ansible_tower_client_ruby,2,2,1,0,0,0,0,0,0,0,1
ManageIQ/FireBreath,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/WinRM,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/actionwebservice,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/active_bugzilla,0,0,0,0,0,0,0,0,0,0,1
ManageIQ/activerecord-sqlserver-adapter,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/amazon_ssa_support,1,2,0,1,0,0,0,0,0,0,1
ManageIQ/awesome_spawn,0,0,0,0,0,0,0,0,0,0,1
ManageIQ/azure-armrest,1,1,0,0,0,0,0,0,0,0,1
ManageIQ/azure-signature,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/binary_struct,1,1,0,0,0,0,0,0,0,0,1
ManageIQ/bugzilla_mirror,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/bugzilla_mirror_client,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/cc_monitor,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/cfme_doc_public,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/config,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/container-memcached,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/container-postgresql,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/container-ruby,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/cruisecontrol.rb,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/deep_merge,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/depot.manageiq.org,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/dhtmlx-rails,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/ec2Extract,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/ffi-vix_disk_lib,1,0,0,0,0,0,0,0,0,0,1
ManageIQ/fog,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/font-fabulous,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/foreman_api_client,2,1,0,0,0,0,0,0,0,0,1
ManageIQ/guides,3,6,0,0,0,0,0,0,0,0,4
ManageIQ/handsoap,0,0,0,0,0,0,0,0,0,0,2
ManageIQ/integration_tests,56,58,1,13,0,0,0,0,0,0,78
ManageIQ/jquery-rjs,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/laptop,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/large_file_linux,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/linux_admin,0,0,0,0,0,0,0,0,0,0,1
ManageIQ/linux_block_device,1,0,0,0,0,0,0,0,0,0,1
ManageIQ/manageiq,121,133,52,20,5,3,5,11,15,8,234
ManageIQ/manageiq-api-client,1,1,0,0,0,0,0,0,0,0,2
ManageIQ/manageiq-api-client-python,0,0,0,0,0,0,0,0,0,0,1
ManageIQ/manageiq-api-mock,3,3,2,0,0,0,0,0,0,0,0
ManageIQ/manageiq-appliance,0,0,0,0,0,0,0,0,0,0,3
ManageIQ/manageiq-appliance-build,0,0,0,0,0,0,0,0,0,0,7
ManageIQ/manageiq-appliance-dev-setup,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/manageiq-automation_engine,21,13,3,1,0,0,0,3,4,3,5
ManageIQ/manageiq-content,10,12,5,1,0,2,0,2,0,2,10
ManageIQ/manageiq-design,0,0,0,0,0,0,0,0,0,0,1
ManageIQ/manageiq-gems-pending,10,16,7,3,1,0,0,0,3,0,14
ManageIQ/manageiq-performance,0,0,0,0,0,0,0,0,0,0,3
ManageIQ/manageiq-pods,5,3,0,0,0,0,0,0,0,0,1
ManageIQ/manageiq-providers-amazon,8,8,4,3,0,1,0,1,0,1,4
ManageIQ/manageiq-providers-azure,4,4,0,2,1,1,0,0,0,0,1
ManageIQ/manageiq-providers-hawkular,6,3,1,0,1,0,0,0,0,1,6
ManageIQ/manageiq-providers-kubernetes,6,7,2,1,1,0,0,2,0,0,3
ManageIQ/manageiq-providers-lenovo,6,9,0,0,0,0,0,0,0,0,1
ManageIQ/manageiq-providers-openshift,5,6,0,0,1,0,0,4,0,0,3
ManageIQ/manageiq-providers-openstack,6,6,3,0,1,0,0,1,0,0,7
ManageIQ/manageiq-providers-ovirt,11,9,4,0,2,0,0,0,1,2,9
ManageIQ/manageiq-providers-vmware,8,8,2,1,0,2,0,2,1,1,4
ManageIQ/manageiq-release,3,1,0,0,0,0,0,0,0,0,2
ManageIQ/manageiq-schema,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/manageiq-ui-admin,0,0,0,0,0,0,0,0,0,0,1
ManageIQ/manageiq-ui-classic,118,120,55,18,0,3,2,12,16,6,106
ManageIQ/manageiq-ui-scaffold,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/manageiq-ui-service,33,33,12,3,0,1,0,1,0,7,2
ManageIQ/manageiq-vagrant-dev,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/manageiq.org,3,7,0,0,0,0,0,0,0,0,6
ManageIQ/manageiq.org_mailman_templates,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/manageiq_depot,0,0,0,0,0,0,0,0,0,0,1
ManageIQ/manageiq_docs,18,12,2,5,0,0,0,0,0,0,8
ManageIQ/manageiq_vm_explorer,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/marketplace-downloads,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/memoist,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/memory_buffer,1,0,0,0,0,0,0,0,0,0,1
ManageIQ/metric_fu,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/miq_bot,3,2,0,0,0,0,0,0,0,0,4
ManageIQ/miq_tools_services,0,0,0,0,0,0,0,0,0,0,4
ManageIQ/more_core_extensions,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/net_app_manageability,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/ovirt,2,2,1,0,0,0,0,0,0,0,0
ManageIQ/ovirt_metrics,1,1,0,0,0,0,0,0,0,0,0
ManageIQ/patternfly-sass,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/pg-dsn_parser,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/pg-pglogical,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/planet.manageiq.org,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/platform,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/polisher,0,0,0,0,0,0,0,0,0,0,2
ManageIQ/princely,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/psych,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/query_relation,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/rack,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/rails,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/rest-client,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/roodi,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/ruby-net-ldap,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/ruby-net-ldap.old,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/rubyrep,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/rubywbem,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/ruport,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/simple-rss,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/slp,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/sneakernet_ca,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/soap4r,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/sprint_statistics,1,1,0,0,0,0,0,0,0,0,1
ManageIQ/srpms,0,0,0,0,0,0,0,0,0,0,1
ManageIQ/trollop,1,1,0,0,0,0,0,0,0,0,3
ManageIQ/ui-components,4,4,2,1,0,0,0,0,0,0,0
ManageIQ/virt_disk,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/virtfs,0,1,0,0,0,0,0,0,0,0,1
ManageIQ/virtfs-camcorderfs,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/virtfs-ext3,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/virtfs-ext4,0,0,0,0,0,0,0,0,0,0,1
ManageIQ/virtfs-fat32,0,0,0,0,0,0,0,0,0,0,4
ManageIQ/virtfs-iso9660,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/virtfs-ntfs,0,0,0,0,0,0,0,0,0,0,1
ManageIQ/virtfs-xfs,0,0,0,0,0,0,0,0,0,0,1
ManageIQ/win32-service,0,0,0,0,0,0,0,0,0,0,0
ManageIQ/wrapanapi,1,1,0,0,0,0,0,0,0,0,3
ManageIQ/ziya,0,0,0,0,0,0,0,0,0,0,0
```
@mfeifer Please review