### PR TITLE
Enhancements for better tracking sprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,28 @@ NUMBER,AUTHOR,ASSIGNEE,LABELS
 ```
 $ bundle exec ruby prs_per_repo.rb
 ...
-Collecting pull_requests closed for: ManageIQ/virtfs-xfs
-Collecting pull_requests closed for: ManageIQ/win32-service
-Collecting pull_requests closed for: ManageIQ/wrapanapi
-Collecting pull_requests closed for: ManageIQ/ziya
-Pull Requests closed from: 2017-01-09 00:00:00 UTC to: 2017-01-23 00:00:00 UTC
-Ansible/ansible_tower_client_ruby: 10
-ManageIQ/FireBreath: 0
-ManageIQ/WinRM: 0
-ManageIQ/actionwebservice: 0
-ManageIQ/active_bugzilla: 0
-ManageIQ/activerecord-sqlserver-adapter: 0
-ManageIQ/awesome_spawn: 1
-ManageIQ/azure-armrest: 2
+Collecting pull_requests for: ManageIQ/manageiq-automation_engine
+  Closed/Unmerged: ["https://github.com/ManageIQ/manageiq-automation_engine/pull/57", "https://github.com/ManageIQ/manageiq-automation_engine/pull/53", "https://github.com/ManageIQ/manageiq-automation_engine/pull/27"]
+  Closed/Merged: ["https://github.com/ManageIQ/manageiq-automation_engine/pull/61"]
+  Closed/Merged Labels: {"bug"=>1, "euwe/backported"=>1, "fine/backported"=>1}
+Collecting pull_requests for: ManageIQ/manageiq-content
+  ERROR: https://github.com/ManageIQ/manageiq-content/pull/138 is missing a Milestone!!!
+  Closed/Unmerged: []
+  Closed/Merged: ["https://github.com/ManageIQ/manageiq-content/pull/169", "https://github.com/ManageIQ/manageiq-content/pull/168", "https://github.com/ManageIQ/manageiq-content/pull/167", "https://github.com/ManageIQ/manageiq-content/pull/166", "https://github.com/ManageIQ/manageiq-content/pull/162", "https://github.com/ManageIQ/manageiq-content/pull/138"]
+  Closed/Merged Labels: {"enhancement"=>2, "fine/backported"=>3, "bug"=>2, "test"=>1, "documentation"=>1, "services"=>1, "euwe/backported"=>1}
+Collecting pull_requests for: ManageIQ/manageiq-design
+  Closed/Unmerged: []
+  Closed/Merged: []
+  Closed/Merged Labels: {}
+...
+
+$ cat prs_per_repo.csv
+Pull Requests from: 2017-08-08 00:00:00 UTC to: 2017-08-22 00:00:00 UTC.  repo,#opened,#merged,closed_bug,closed_enhancement,closed_developer,closed_documentation,closed_performance,closed_refactoring,closed_technical debt,closed_test,#remaining_open
+Ansible/ansible_tower_client_ruby,1,1,1,1,0,0,0,0,0,0,2
+ManageIQ/FireBreath,0,0,0,0,0,0,0,0,0,0,0
+ManageIQ/WinRM,1,0,0,0,0,0,0,0,0,0,1
+ManageIQ/actionwebservice,1,0,0,0,0,0,0,0,0,0,1
+ManageIQ/active_bugzilla,0,0,0,0,0,0,0,0,0,0,1
+ManageIQ/activerecord-id_regions,0,0,0,0,0,0,0,0,0,0,0
 ...
 ```

--- a/closed_issues_manageiq_repos.rb
+++ b/closed_issues_manageiq_repos.rb
@@ -3,18 +3,14 @@ MILESTONE    = "title of end of sprint milestone"
 
 require_relative 'sprint_statistics'
 def stats
-  @stats ||= SprintStatistics.new(ACCESS_TOKEN)
-end
-
-def repos_to_track
-  stats.project_names_from_org("ManageIQ").to_a + ["Ansible/ansible_tower_client_ruby"]
+  @stats ||= SprintStatistics.new(ACCESS_TOKEN, MILESTONE)
 end
 
 prs = []
 title = ""
 
-repos_to_track.each do |repo|
-  milestone = stats.client.milestones(repo, :state => "all").detect { |m| m[:title] == MILESTONE }
+stats.default_repos.each do |repo|
+  milestone = stats.find_milestone_in_repo(repo)
   if milestone
     puts "Milestone found for #{repo}, collecting."
     title = milestone.title

--- a/prs_per_repo.rb
+++ b/prs_per_repo.rb
@@ -1,45 +1,27 @@
 ACCESS_TOKEN = "your github access token"
+MILESTONE    = "Sprint 58 Ending Apr 10, 2017"
 
 require_relative 'sprint_statistics'
 require 'more_core_extensions/core_ext/array/element_counts'
 
 def stats
-  @stats ||= SprintStatistics.new(ACCESS_TOKEN)
-end
-
-def most_recent_monday
-  @most_recent_monday ||= begin
-    time = Time.now.utc.midnight
-    loop do
-      break if time.monday?
-      time -= 1.day
-    end
-    time
-  end
-end
-
-def sprint_range
-  @sprint_range ||= ((most_recent_monday - 2.weeks)..most_recent_monday)
-end
-
-def repos_to_track
-  stats.project_names_from_org("ManageIQ").to_a + ["Ansible/ansible_tower_client_ruby"]
+  @stats ||= SprintStatistics.new(ACCESS_TOKEN, MILESTONE)
 end
 
 labels  = ["bug", "enhancement", "developer", "documentation", "performance", "refactoring", "technical debt", "test", ]
 results = []
-repos_to_track.sort.each do |repo|
+stats.default_repos.sort.each do |repo|
   puts "Collecting pull_requests for: #{repo}"
-  prs                = stats.pull_requests(repo, :state => :all, :since => sprint_range.first.iso8601)
-  closed             = prs.select { |pr| sprint_range.include?(pr.closed_at) }
+  prs                = stats.pull_requests(repo, :state => :all, :since => stats.sprint_range.first.iso8601)
+  closed             = prs.select { |pr| stats.sprint_range.include?(pr.closed_at) }
   closed_labels_hash = closed.each_with_object([]) { |pr, arr| pr.labels.each { |label| arr << label.name } }.element_counts
-  opened             = prs.select { |pr| sprint_range.include?(pr.created_at) }
+  opened             = prs.select { |pr| stats.sprint_range.include?(pr.created_at) }
   prs_remaining_open = stats.raw_pull_requests(repo, :state => :open).length
   labels_string      = closed_labels_hash.values_at(*labels).collect(&:to_i).join(",")
   results << "#{repo},#{opened.length},#{closed.length},#{labels_string},#{prs_remaining_open}"
 end
 
 File.open('prs_per_repo.csv', 'w') do |f|
-  f.puts "Pull Requests from: #{sprint_range.first} to: #{sprint_range.last}.  repo,#opened,#closed,#{labels.collect { |l| "closed_#{l}" }.join(",")},#remaining_open"
+  f.puts "Pull Requests from: #{stats.sprint_range.first} to: #{stats.sprint_range.last}.  repo,#opened,#closed,#{labels.collect { |l| "closed_#{l}" }.join(",")},#remaining_open"
   results.each { |line| f.puts(line) }
 end

--- a/prs_per_repo.rb
+++ b/prs_per_repo.rb
@@ -8,20 +8,48 @@ def stats
   @stats ||= SprintStatistics.new(ACCESS_TOKEN, MILESTONE)
 end
 
+def merged?(repo, number)
+  stats.client.pull_request(repo, number).merged?
+end
+
+def pr_issues(repo)
+  stats.pull_requests(repo, :state => :all, :since => stats.sprint_range.first.iso8601)
+end
+
 labels  = ["bug", "enhancement", "developer", "documentation", "performance", "refactoring", "technical debt", "test", ]
 results = []
 stats.default_repos.sort.each do |repo|
   puts "Collecting pull_requests for: #{repo}"
-  prs                = stats.pull_requests(repo, :state => :all, :since => stats.sprint_range.first.iso8601)
-  closed             = prs.select { |pr| stats.sprint_range.include?(pr.closed_at) }
-  closed_labels_hash = closed.each_with_object([]) { |pr, arr| pr.labels.each { |label| arr << label.name } }.element_counts
-  opened             = prs.select { |pr| stats.sprint_range.include?(pr.created_at) }
+  milestone = stats.find_milestone_in_repo(repo)
+  opened = 0
+  closed_merged = []
+  closed_unmerged = []
+  labels_arr = []
+  pr_issues(repo).each do |i|
+    opened += 1 if stats.sprint_range.include?(i.created_at)
+
+    next unless stats.sprint_range.include?(i.closed_at)
+
+    if merged?(repo, i.number)
+      closed_merged << i
+      i.labels.each { |label| labels_arr << label.name }
+      puts "  ERROR: #{i.html_url} is missing a Milestone!!!" if milestone && !i.milestone?
+    else
+      closed_unmerged << i
+      puts "  ERROR: #{i.html_url} has a Milestone and shouldn't!!!" if i.milestone?
+    end
+  end
   prs_remaining_open = stats.raw_pull_requests(repo, :state => :open).length
-  labels_string      = closed_labels_hash.values_at(*labels).collect(&:to_i).join(",")
-  results << "#{repo},#{opened.length},#{closed.length},#{labels_string},#{prs_remaining_open}"
+  merged_labels_hash = labels_arr.element_counts
+  labels_string      = merged_labels_hash.values_at(*labels).collect(&:to_i).join(",")
+  results << "#{repo},#{opened},#{closed_merged.length},#{labels_string},#{prs_remaining_open}"
+
+  puts "  Closed/Unmerged: #{closed_unmerged.collect(&:html_url).inspect}"
+  puts "  Closed/Merged: #{closed_merged.collect(&:html_url).inspect}"
+  puts "  Closed/Merged Labels: #{merged_labels_hash.inspect}"
 end
 
 File.open('prs_per_repo.csv', 'w') do |f|
-  f.puts "Pull Requests from: #{stats.sprint_range.first} to: #{stats.sprint_range.last}.  repo,#opened,#closed,#{labels.collect { |l| "closed_#{l}" }.join(",")},#remaining_open"
+  f.puts "Pull Requests from: #{stats.sprint_range.first} to: #{stats.sprint_range.last}.  repo,#opened,#merged,#{labels.collect { |l| "closed_#{l}" }.join(",")},#remaining_open"
   results.each { |line| f.puts(line) }
 end

--- a/sprint_statistics.rb
+++ b/sprint_statistics.rb
@@ -2,7 +2,7 @@ require 'active_support'
 require 'active_support/core_ext'
 
 class SprintStatistics
-  def initialize(access_token, milestone_string)
+  def initialize(access_token, milestone_string = nil)
     @access_token = access_token
     @milestone_string = milestone_string
   end

--- a/sprint_statistics.rb
+++ b/sprint_statistics.rb
@@ -16,7 +16,11 @@ class SprintStatistics
   end
 
   def previous_milestone
-    @previous_milestone ||= client.milestone("ManageIQ/manageiq", (current_milestone.number - 1))
+    @previous_milestone ||= begin
+      current_milestone_number = current_milestone.title.match(/Sprint (\d+)/)[1].to_i
+      previous_milestone_number = current_milestone_number - 1
+      client.milestones("ManageIQ/manageiq", :state => "all").detect { |m| m.title.start_with?("Sprint #{previous_milestone_number}") }
+    end
   end
 
   def sprint_range

--- a/sprint_statistics.rb
+++ b/sprint_statistics.rb
@@ -7,8 +7,12 @@ class SprintStatistics
     @milestone_string = milestone_string
   end
 
+  def find_milestone_in_repo(repo)
+    client.milestones(repo, :state => "all").detect { |m| m.title == @milestone_string }
+  end
+
   def current_milestone
-    @current_milestone ||= client.milestones("ManageIQ/manageiq", :state => "all").detect { |m| m.title == @milestone_string }
+    @current_milestone ||= find_milestone_in_repo("ManageIQ/manageiq")
   end
 
   def previous_milestone

--- a/sprint_statistics.rb
+++ b/sprint_statistics.rb
@@ -2,8 +2,25 @@ require 'active_support'
 require 'active_support/core_ext'
 
 class SprintStatistics
-  def initialize(access_token)
+  def initialize(access_token, milestone_string)
     @access_token = access_token
+    @milestone_string = milestone_string
+  end
+
+  def current_milestone
+    @current_milestone ||= client.milestones("ManageIQ/manageiq", :state => "all").detect { |m| m.title == @milestone_string }
+  end
+
+  def previous_milestone
+    @previous_milestone ||= client.milestone("ManageIQ/manageiq", (current_milestone.number - 1))
+  end
+
+  def sprint_range
+    @sprint_range ||= ((previous_milestone.due_on.utc.midnight + 1.day)..(current_milestone.due_on.utc.midnight + 1.day))
+  end
+
+  def default_repos
+    @default_repos ||= stats.project_names_from_org("ManageIQ").to_a + ["Ansible/ansible_tower_client_ruby"]
   end
 
   def client


### PR DESCRIPTION
- Change from collecting the number of closed issues to tracking the merged PR's.
- Add more diagnostic output so that the user can tell which PR's are merged or just closed.
- Add an error for PR's that are missing a milestone
- Add an error for PR's that have a milestone and shouldn't
- Base the sprint range on the desired sprint milestone and the previous sprint milestone.  This is much easier and more reliable than the "most recent monday" logic.

@JPrause Please review
cc @bronaghs @mfeifer 