### PR TITLE
Faster statistics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 gem 'activesupport',        "~> 5.0", :require => false
 gem 'more_core_extensions',           :require => false
 gem 'octokit',              "~> 4.3", :require => false
+gem 'parallel',                       :require => false

--- a/config.yaml
+++ b/config.yaml
@@ -3,10 +3,18 @@
 :milestone_reference_repo: ManageIQ/manageiq
 :additional_repos: []
 :excluded_repos:
-- ManageIQ/handsoap
-- ManageIQ/sprint_statistics
+- ManageIQ/active_bugzilla
+- ManageIQ/bugzilla_mirror
+- ManageIQ/bugzilla_mirror_client
 - ManageIQ/integration_tests
-- ManageIQ/guides
+- ManageIQ/manageiq-appliance-dev-setup
+- ManageIQ/manageiq-performance
+- ManageIQ/manageiq-release
+- ManageIQ/manageiq-vagrant-dev
+- ManageIQ/miq_tools_services
+- ManageIQ/polisher
+- ManageIQ/sprint_statistics
+- ManageIQ/wrapanapi
 :priority:
 - :prefix: E
   :label: enhancement

--- a/sprint_statistics.rb
+++ b/sprint_statistics.rb
@@ -73,7 +73,7 @@ class SprintStatistics
   end
 
   def project_names_from_org(org)
-    fetch(:repositories, org).collect(&:full_name)
+    fetch(:repositories, org).reject { |r| r.archived? || r.fork? }.collect(&:full_name)
   end
 
   def raw_pull_requests(repo, options = {})


### PR DESCRIPTION
~~Built on top of #28 (so just look at the last 3 commits - https://github.com/ManageIQ/sprint_statistics/compare/638fc2c~...949b02d  )~~

Speeds up the run on my machine from 190 seconds to 10 seconds.

- Eliminate a lot of useless repos, such as forked and archived repos.
- When querying repos without milestones, use the `:since` parameter to limit the number of returned issues to only those in the last 2 weeks.
- Parallelize the GitHub queries

@jvlcek Please review.