### PR TITLE
Use actual sprint ranges instead of a hardcoded 2 weeks

### DIFF
--- a/merged_prs_per_sprint.rb
+++ b/merged_prs_per_sprint.rb
@@ -124,9 +124,7 @@ def write_repo_prs(fq_repo_name, prs, total_pr_count, f)
   prioritize_prs(prs).each { |pr| f.puts "#{pr.category}, #{pr.user.login},#{title_markdown(pr)}<br/>" }
 end
 
-def process_repos(milestone_title)
-  milestone_range = Milestone.range(milestone_title)
-
+def process_repos(milestone_title, milestone_range)
   File.open("merged_prs_for #{milestone_title}.md", 'w') do |f|
     write_stdout_and_file(f, "Milestone Statistics for: \"#{milestone_title}\"  (#{milestone_range})")
     write_stdout_and_file(f, "")
@@ -154,8 +152,6 @@ def completed_in
   puts "Completed in #{Time.now - start_time}"
 end
 
-milestone = Milestone.prompt_for_milestone
-exit if milestone.nil?
-milestone = milestone.title
-
-completed_in { process_repos(milestone) }
+sprint = Milestone.prompt_for_sprint
+exit if sprint.nil?
+completed_in { process_repos(sprint.title, sprint.range) }

--- a/milestone.rb
+++ b/milestone.rb
@@ -1,55 +1,60 @@
-require_relative 'sprint_statistics'
-require 'active_support/core_ext/time/calculations'
-require 'active_support/values/time_zone'
-
 class Milestone
-  def self.milestones
-    @milestones ||= begin
-      config = YAML.load_file('config.yaml')
-      stats = SprintStatistics.new(ENV["GITHUB_API_TOKEN"])
-      stats.client.milestones(config[:milestone_reference_repo], :state => "all")
-    end
+  def self.prompt_for_sprint
+    sprints = recent_sprints(3).reverse
+    default_index = Date.today == sprints.first.range.begin ? 1 : 0
+    sprints[prompt_user(sprints, default_index)]
   end
 
-  def self.sorted_milestones
-    milestones.sort_by(&:created_at)
-  end
+  def self.prompt_user(sprints, default_index)
+    default_index += 1
 
-  def self.day_after_milestone_change?(milestone)
-    range(milestone.title).first + 1 == Date.today
-  end
+    sprints.each_with_index { |s, i| puts "#{i + 1} : #{s.title}" }
+    puts "#{sprints.size + 1} : Exit"
+    print "\nChoose Milestone: [Default: #{default_index}] "
 
-  def self.prompt_for_milestone(options = {})
-    options.reverse_merge!(
-      :default_index => 1,
-      :count         => 3
-    )
-
-    display_milestones = sorted_milestones[options[:count] * -1..-1].reverse
-    if day_after_milestone_change?(display_milestones.first)
-      options[:default_index] += 1
-    end
-
-    print_milestones_prompt(display_milestones, options)
-
-    index = prompt_user(options)
-    display_milestones[index - 1]
-  end
-
-  def self.print_milestones_prompt(milestones, options)
-    milestones.each_with_index { |m, idx| puts "#{idx + 1} : #{m.title}" }
-    puts "#{options[:count] + 1} : Exit"
-    print "\nChoose Milestone: [Default: #{options[:default_index]}] "
-  end
-
-  def self.prompt_user(options)
     answer = gets.chomp.to_i
-    answer.zero? ? options[:default_index] : answer
+    (answer.zero? ? default_index : answer) - 1
   end
 
-  def self.range(milestone_title)
-    end_date = Date.parse(milestone_title)
-    start_date = end_date - 2.weeks
-    Range.new(start_date, end_date)
+  def self.recent_sprints(count)
+    sprints(as_of: nil).slice_after { |s| s.date >= Date.today }.first.last(count)
+  end
+
+  def self.sprints(as_of: Date.today)
+    require "active_support/core_ext/numeric/time"
+    # The first date when we started doing this cadence
+    number = 76
+    date   = Date.parse("Jan 1, 2018")
+    range  = Date.parse("Dec 12, 2018")..date
+
+    as_of ||= date
+
+    Enumerator.new do |y|
+      loop do
+        y << new(number, range) if date >= as_of
+
+        last_date = date
+        number += 1
+        date += 2.weeks
+        while (date.month == 12 && (22..31).cover?(date.day)) || (date.month == 1 && (1..4).cover?(date.day))
+          date += 1.weeks
+        end
+        range = (last_date + 1.day)..date
+      end
+    end
+  end
+
+  attr_reader :number, :range
+
+  def initialize(number, range)
+    @number, @range = number, range
+  end
+
+  def date
+    range.end
+  end
+
+  def title
+    "Sprint #{number} Ending #{date.strftime("%b %-d, %Y")}"
   end
 end


### PR DESCRIPTION
This commit leverages the sprint number generator from manageiq-release,
changing it a bit to yield an object and to include the range inside
that object.

```sh
$ ruby merged_prs_per_sprint.rb
1 : Sprint 127 Ending Jan 6, 2020
2 : Sprint 126 Ending Dec 9, 2019
3 : Sprint 125 Ending Nov 25, 2019
4 : Exit

Choose Milestone: [Default: 1] 1
Milestone Statistics for: "Sprint 127 Ending Jan 6, 2020"  (2019-12-10..2020-01-06)
```

Notice that this last sprint uses the actual range, which is 4 weeks.

@bdunne Please review