### PR TITLE
Changes to simplify back to back runs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,4 @@ gem 'activesupport',        "~> 5.0", :require => false
 gem 'more_core_extensions',           :require => false
 gem 'octokit',              "~> 4.3", :require => false
 gem 'parallel',                       :require => false
+gem 'optimist',                       :require => false

--- a/merged_prs_per_sprint.rb
+++ b/merged_prs_per_sprint.rb
@@ -5,7 +5,7 @@ require 'yaml'
 @config = YAML.load_file('config.yaml')
 
 def github_api_token
-  @github_api_token ||= ENV["GITHUB_API_TOKEN"]
+  @github_api_token ||= ENV["GITHUB_API_TOKEN"] || @config[:access_token]
 end
 
 def stats

--- a/merged_prs_per_sprint.rb
+++ b/merged_prs_per_sprint.rb
@@ -1,148 +1,187 @@
 require_relative 'sprint_statistics'
 require_relative 'sprint'
 require 'yaml'
+require 'optimist'
 
-@config = YAML.load_file('config.yaml')
+class MergedPrs
+  attr_reader :config, :config_file, :output_file, :sprint
 
-def github_api_token
-  @github_api_token ||= ENV["GITHUB_API_TOKEN"] || @config[:access_token]
-end
+  def initialize(opts)
+    @sprint = Sprint.prompt_for_sprint(3)
+    exit if @sprint.nil?
 
-def stats
-  @stats ||= SprintStatistics.new(github_api_token)
-end
+    @config_file = opts[:config_file]
+    @config = YAML.load_file(@config_file)
 
-def priorities
-  @priorities ||= begin
-    @config.dig(:priority).tap do |priority|
-      priority.each_with_index { |p, idx| p[:index] = idx }
-    end
+    @output_file = opts[:output_file] || "merged_prs_for #{@sprint.title}.md"
   end
-end
 
-def user_filters
-  @user_filters ||= (@config.dig(:filters, :users) || []).map(&:downcase)
-end
+  def github_api_token
+    @github_api_token ||= ENV["GITHUB_API_TOKEN"] || @config[:access_token]
+  end
 
-def label_filters
-  @label_filters ||= @config.dig(:filters, :labels) || []
-end
+  def stats
+    @stats ||= SprintStatistics.new(github_api_token)
+  end
 
-def repos_to_track
-  organization = @config[:github_organization]
-  puts "Loading Organization: #{organization}"
-
-  repos = stats.project_names_from_org(organization).to_a + @config[:additional_repos].to_a
-  repos - @config[:excluded_repos].to_a
-end
-
-def filters_match?(pr)
-  return true if user_filters.include?(pr.user.login.downcase)
-  return true unless (label_filters & pr.labels.collect(&:name)).blank?
-
-  false
-end
-
-def filter_repo_prs?(fq_repo_name)
-  return false if user_filters.blank? && label_filters.blank?
-
-  !@config.dig(:filters, :non_filtered_repos).include?(fq_repo_name)
-end
-
-def prioritize_prs(prs)
-  prs.each do |pr|
-    priority = priorities.detect { |p| pr.label_names.include?(p[:label]) }
-    pr.priority, pr.category = if priority
-                                 [priority[:index], priority[:prefix]]
-                               else
-                                 [priorities.count, '']
-                               end
-  end.sort_by(&:priority)
-end
-
-def title_markdown(pr)
-  "[#{pr.title} (##{pr.number})](#{pr.pull_request.html_url})"
-end
-
-def milestone_prs(milestone, sprint_range, fq_repo_name)
-  params = {:state => "closed", :sort => 'closed_at', :direction => 'desc'}
-
-  prs =
-    if milestone
-      stats.pull_requests(fq_repo_name, params.merge(:milestone => milestone.number))
-    else
-      since = sprint_range.begin.in_time_zone("US/Pacific").iso8601
-      stats.pull_requests(fq_repo_name, params.merge(:since => since)).select do |pr|
-        sprint_range.include?(pr.updated_at.to_date)
+  def priorities
+    @priorities ||= begin
+      @config.dig(:priority).tap do |priority|
+        priority.each_with_index { |p, idx| p[:index] = idx }
       end
     end
-
-  prs.each { |pr| pr.label_names = pr.labels.collect(&:name) }
-  prs
-end
-
-def write_stdout_and_file(f, line)
-  puts line
-  f.puts line + "<br/>"
-end
-
-def prs_for_milestone(milestone, sprint_range, fq_repo_name)
-  all_prs = milestone_prs(milestone, sprint_range, fq_repo_name)
-
-  if filter_repo_prs?(fq_repo_name)
-    prs = all_prs.select { |pr| filters_match?(pr) }
-  else
-    prs = all_prs
   end
 
-  [prs, all_prs.count]
-end
-
-def fetch_repo_prs_parallel(repos, sprint)
-  require 'parallel'
-
-  puts "Fetching..."
-  repo_prs = Parallel.map(repos, :in_threads => 8) do |fq_repo_name|
-    puts "  #{fq_repo_name}"
-    [fq_repo_name, fetch_repo_prs(fq_repo_name, sprint)]
+  def user_filters
+    @user_filters ||= (@config.dig(:filters, :users) || []).map(&:downcase)
   end
-  puts
 
-  repo_prs
-end
+  def label_filters
+    @label_filters ||= @config.dig(:filters, :labels) || []
+  end
 
-def fetch_repo_prs(fq_repo_name, sprint)
-  # Each repo has a different milestone number, so we have to lookup by name
-  milestone = stats.client.milestones(fq_repo_name, :state => "all").detect { |m| m[:title] == sprint.title }
+  def repos_to_track
+    organization = @config[:github_organization]
+    puts "Loading Organization: #{organization}"
 
-  prs_for_milestone(milestone, sprint.range, fq_repo_name)
-end
+    repos = stats.project_names_from_org(organization).to_a + @config[:additional_repos].to_a
+    repos - @config[:excluded_repos].to_a
+  end
 
-def write_repo_prs(fq_repo_name, prs, total_pr_count, f)
-  f.puts('')
-  write_stdout_and_file(f, "Repo: #{fq_repo_name}  PR (Selected/Total): (#{prs.count}/#{total_pr_count})")
-  prioritize_prs(prs).each { |pr| f.puts "#{pr.category}, #{pr.user.login},#{title_markdown(pr)}<br/>" }
-end
+  def filters_match?(pr)
+    return true if user_filters.include?(pr.user.login.downcase)
+    return true unless (label_filters & pr.labels.collect(&:name)).blank?
 
-def process_repos(sprint)
-  File.open("merged_prs_for #{sprint.title}.md", 'w') do |f|
-    puts "\n"
-    write_stdout_and_file(f, "Sprint Statistics for: \"#{sprint.title}\"  (#{sprint.range})")
-    write_stdout_and_file(f, "")
+    false
+  end
 
-    repo_prs = fetch_repo_prs_parallel(repos_to_track, sprint)
+  def filter_repo_prs?(fq_repo_name)
+    return false if user_filters.blank? && label_filters.blank?
 
-    empty_repos = []
-    repo_prs.each do |fq_repo_name, (prs, total_pr_count)|
-      if prs.empty?
-        empty_repos << fq_repo_name
+    !@config.dig(:filters, :non_filtered_repos).include?(fq_repo_name)
+  end
+
+  def prioritize_prs(prs)
+    prs.each do |pr|
+      priority = priorities.detect { |p| pr.label_names.include?(p[:label]) }
+      pr.priority, pr.category = if priority
+                                   [priority[:index], priority[:prefix]]
+                                 else
+                                   [priorities.count, '']
+                                 end
+    end.sort_by(&:priority)
+  end
+
+  def title_markdown(pr)
+    "[#{pr.title} (##{pr.number})](#{pr.pull_request.html_url})"
+  end
+
+  def milestone_prs(milestone, sprint_range, fq_repo_name)
+    params = {:state => "closed", :sort => 'closed_at', :direction => 'desc'}
+
+    prs =
+      if milestone
+        stats.pull_requests(fq_repo_name, params.merge(:milestone => milestone.number))
       else
-        write_repo_prs(fq_repo_name, prs, total_pr_count, f)
+        since = sprint_range.begin.in_time_zone("US/Pacific").iso8601
+        stats.pull_requests(fq_repo_name, params.merge(:since => since)).select do |pr|
+          sprint_range.include?(pr.updated_at.to_date)
+        end
       end
+
+    prs.each { |pr| pr.label_names = pr.labels.collect(&:name) }
+    prs
+  end
+
+  def write_stdout_and_file(f, line)
+    puts line
+    f.puts line + "<br/>"
+  end
+
+  def prs_for_milestone(milestone, sprint_range, fq_repo_name)
+    all_prs = milestone_prs(milestone, sprint_range, fq_repo_name)
+
+    if filter_repo_prs?(fq_repo_name)
+      prs = all_prs.select { |pr| filters_match?(pr) }
+    else
+      prs = all_prs
     end
 
+    [prs, all_prs.count]
+  end
+
+  def fetch_repo_prs_parallel(repos)
+    require 'parallel'
+
+    puts "Fetching..."
+    repo_prs = Parallel.map(repos, :in_threads => 8) do |fq_repo_name|
+      puts "  #{fq_repo_name}"
+      [fq_repo_name, fetch_repo_prs(fq_repo_name)]
+    end
     puts
-    puts "Empty Repos: #{empty_repos.count}\nRepo List: #{empty_repos.join(", ")}"
+
+    repo_prs
+  end
+
+  def fetch_repo_prs(fq_repo_name)
+    # Each repo has a different milestone number, so we have to lookup by name
+    milestone = stats.client.milestones(fq_repo_name, :state => "all").detect { |m| m[:title] == @sprint.title }
+
+    prs_for_milestone(milestone, @sprint.range, fq_repo_name)
+  end
+
+  def write_repo_prs(fq_repo_name, prs, total_pr_count, f)
+    f.puts('')
+    write_stdout_and_file(f, "Repo: #{fq_repo_name}  PR (Selected/Total): (#{prs.count}/#{total_pr_count})")
+    prioritize_prs(prs).each { |pr| f.puts "#{pr.category}, #{pr.user.login},#{title_markdown(pr)}<br/>" }
+  end
+
+  def process_repos
+    File.open(@output_file, 'w') do |f|
+      puts "\n"
+      write_stdout_and_file(f, "Sprint Statistics for: \"#{@sprint.title}\"  (#{@sprint.range})")
+      write_stdout_and_file(f, "")
+
+      repo_prs = fetch_repo_prs_parallel(repos_to_track)
+
+      empty_repos = []
+      repo_prs.each do |fq_repo_name, (prs, total_pr_count)|
+        if prs.empty?
+          empty_repos << fq_repo_name
+        else
+          write_repo_prs(fq_repo_name, prs, total_pr_count, f)
+        end
+      end
+
+      puts
+      puts "Empty Repos: #{empty_repos.count}\nRepo List: #{empty_repos.join(", ")}"
+    end
+  end
+
+  def self.parse(args)
+    opts = Optimist.options(args) do
+      banner "Usage: ruby #{$PROGRAM_NAME} [opts]\n"
+
+      opt :config_file,
+          "Config file name",
+          :short    => "c",
+          :default  => "config.yaml",
+          :type     => :string,
+          :required => false
+
+      opt :output_file,
+          "Output file name",
+          :short    => "o",
+          :default  => nil,
+          :type     => :string,
+          :required => false
+    end
+
+    opts
+  end
+
+  def self.run(args)
+    new(parse(args)).process_repos
   end
 end
 
@@ -153,6 +192,5 @@ def completed_in
   puts "Completed in #{Time.now - start_time}"
 end
 
-sprint = Sprint.prompt_for_sprint(3)
-exit if sprint.nil?
-completed_in { process_repos(sprint) }
+completed_in { MergedPrs.run(ARGV) }
+


### PR DESCRIPTION
This PR will simplify performing multiple consecutive runs of the `merged_prs_for_sprint.rb` script with different criteria.

It does this by allowing the user to specify the name of the config file and the output file on the command line.

This will be helpful for generating  the Platform sprint review PR lists which are generated using two separate executions with two different config  files. This PR will allow the user to avoid having to copy the first config file to `config.yaml`, run the script, save that output to a different file, then repeat the process with a different config file.

Instead the user will be able to simply run two commands of the form:

```bash
ruby merged_prs_per_sprint.rb -c exclude_all_non_platform_repos_config.yaml -o exclude_all_non_platform_repos.md
ruby merged_prs_per_sprint.rb -c only_manageiq_config.yaml -o only_manageiq.md
```
 
It is clear further refinement could be made to allow for a single run with multiple config files but in the spirit of making incremental smaller improvements, updates of that nature are  beyond the scope of this initial PR.

Another, less significant, change in this PR is to allow the github API token to alternatively be read from the config YAML file.