### PR TITLE
Merged PRs by org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Gemfile.lock
 *.md
 *.csv
+config*.yaml

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,5 @@
 ---
 :github_organization: ManageIQ
-:milestone_reference_repo: ManageIQ/manageiq
 :additional_repos: []
 :excluded_repos:
 - ManageIQ/integration_tests


### PR DESCRIPTION
This PR changes the approach of how merged PRs are identified for the organization.

Instead of listing each repo 1-by-1 and looking through PRs to find if it was merged within the expect range it now does an organization wide search for PRs in the date range.

The reduces the logic down to one API call (plus octokit auto-pagination) to get only the merged PRs.
This is exactly the same as going to https://github.com/pulls and searching for [archived:false user:ManageIQ merged:2020-03-03..2020-03-16](https://github.com/pulls?q=archived%3Afalse+user%3AManageIQ+merged%3A2020-03-03..2020-03-16)

In a few tests this dropped the scan from about 10 seconds to 5.

The parallel processing of repos remains in support of the "additional_repos" config option which allows for selecting repos outside of the defined organization.

Note: The "Empty Repos" listing will be much smaller now since the organizational query only lists merged PRs, so we do not pick up every repo in the org like before.

I also tried to make the output a little easier to read.

Finally, added `config*.yaml` to `.gitignore` and removed the now unused `milestone_reference_repo` config property.

Example output:
```
$ ruby merged_prs_per_sprint.rb
1 : Sprint 132 Ending Mar 16, 2020
2 : Sprint 131 Ending Mar 2, 2020
3 : Sprint 130 Ending Feb 17, 2020
4 : Exit

Choose Milestone: [Default: 1] 

Total merged PRs for Organization ManageIQ: 172 (unfiltered count)
Sprint Statistics for: "Sprint 132 Ending Mar 16, 2020"  (2020-03-03..2020-03-16)

Name                                         	 PRs: (Selected/Total)
ManageIQ/manageiq                            	 32 / 32
ManageIQ/manageiq-providers-vmware           	  2 / 2
ManageIQ/miq_bot                             	  3 / 3
ManageIQ/manageiq-pods                       	  6 / 6
ManageIQ/manageiq-ui-classic                 	 31 / 31
ManageIQ/manageiq-appliance-build            	  3 / 3
ManageIQ/manageiq-ui-service                 	  2 / 2
ManageIQ/manageiq-api                        	 10 / 10
ManageIQ/manageiq-providers-openstack        	  2 / 2
ManageIQ/manageiq-providers-azure            	  1 / 1
ManageIQ/manageiq-providers-foreman          	  3 / 3
ManageIQ/guides                              	  7 / 7
ManageIQ/manageiq_docs                       	  3 / 3
ManageIQ/manageiq-providers-amazon           	  3 / 3
ManageIQ/manageiq-providers-redfish          	  2 / 2
ManageIQ/manageiq-providers-nuage            	  2 / 2
ManageIQ/manageiq-providers-lenovo           	  2 / 2
ManageIQ/manageiq-v2v                        	  1 / 1
ManageIQ/manageiq-v2v-conversion_host-build  	  1 / 1
ManageIQ/manageiq-providers-ansible_tower    	  3 / 3
ManageIQ/manageiq-providers-ovirt            	  6 / 6
ManageIQ/manageiq-appliance                  	  1 / 1
ManageIQ/manageiq.org                        	  4 / 4
ManageIQ/manageiq-automation_engine          	  1 / 1
ManageIQ/manageiq-providers-openshift        	  1 / 1
ManageIQ/manageiq-providers-azure_stack      	  1 / 1
ManageIQ/manageiq-providers-google           	  2 / 2
ManageIQ/manageiq-decorators                 	  1 / 1
ManageIQ/manageiq-providers-kubernetes       	  1 / 1
ManageIQ/manageiq-appliance_console          	  2 / 2
ManageIQ/manageiq-cross_repo                 	  1 / 1
ManageIQ/manageiq-v2v-conversion_host        	  1 / 1
ManageIQ/manageiq-schema                     	  1 / 1
ManageIQ/manageiq-api-client                 	  1 / 1

Empty Repos: 0    name(unfiltered PR count)

Output written to: merged_prs_for Sprint 132 Ending Mar 16, 2020.md
Completed in 6.683402
```