### PR TITLE
interact with CodeClimate to help automate repo health for sprint review

### DIFF
--- a/code_climate.rb
+++ b/code_climate.rb
@@ -1,0 +1,175 @@
+require "net/http"
+require "json"
+require "active_support/core_ext"
+
+CODECLIMATE_API_TOKEN = "your CodeClimage API token"
+CODECLIMATE_URL       = "https://api.codeclimate.com"
+
+class CodeClimateRequest
+  def initialize
+    @base_uri  = ENV["CODECLIMATE_URL"]       || CODECLIMATE_URL
+    @api_token = ENV["CODECLIMATE_API_TOKEN"] || CODECLIMATE_API_TOKEN
+  end
+
+  def request(path)
+    uri = URI("#{@base_uri}#{path}")
+    if ENV["DEBUG"] == "1"
+      STDERR.puts uri.to_s
+    end
+    http = Net::HTTP.new(uri.hostname, uri.port)
+    http.use_ssl = uri.scheme == "https" ? true : false
+    request = Net::HTTP::Get.new(uri.request_uri)
+    request.set_content_type("application/vnd.api+json")
+    request["Authorization"] = "Token token=#{@api_token}"
+    http.request(request)
+  end
+end
+
+class CodeClimate
+  def self.repo_stats(repo_name)
+    cc = CodeClimate.new
+    repo = cc.repo_from_github_slug(repo_name)
+    return {} if repo.nil?
+    
+    repo_id     = repo["id"]
+    snapshot_id = repo["relationships"]["latest_default_branch_snapshot"]["data"]["id"]
+
+    snapshot = cc.snapshot(repo_id, snapshot_id)
+    files    = cc.files(repo_id, snapshot_id)
+    issues   = cc.issues(repo_id, snapshot_id)
+
+    issue_counts = {}
+    issue_counts['total']       = issues.length
+    issue_counts['complexity']  = issues.count { |issue| issue["attributes"]["categories"].include?("Complexity") }
+    issue_counts['duplication'] = issues.count { |issue| issue["attributes"]["categories"].include?("Duplication") }
+    issue_counts['style']       = issues.count { |issue| issue["attributes"]["categories"].include?("Style") }
+    issue_counts['bug_risk']    = issues.count { |issue| issue["attributes"]["categories"].include?("Bug Risk") }
+
+    {
+      'files'  => files.length,
+      'loc'    => snapshot['attributes']['lines_of_code'],
+      'issues' => issue_counts,
+      'rating' => snapshot['attributes']['ratings'].first['letter']
+    }
+  end
+
+  def repo_from_github_slug(slug)
+    query = { "github_slug" => slug }
+    path = "/v1/repos?#{query.to_query}"
+    response = CodeClimateRequest.new.request(path)
+    response_to_data(response, path)&.first
+  end
+
+  def repo_from_id(id)
+    path = "/v1/repos/#{id}"
+    response = CodeClimateRequest.new.request(path)
+    response_to_data(response, path)&.first
+  end
+
+  def services(repo_id)
+    path = "/v1/repos/#{repo_id}/services"
+    response = CodeClimateRequest.new.request(path)
+    response_to_data(response, path)
+  end
+
+  def snapshot(repo_id, snapshot_id)
+    path = "/v1/repos/#{repo_id}/snapshots/#{snapshot_id}"
+    response = CodeClimateRequest.new.request(path)
+    response_to_data(response, path)
+  end
+
+  def issues(repo_id, snapshot_id)
+    result = []
+    page_number = 0
+    query = {
+      "page[size]"   => 100,
+      "page[number]" => page_number
+    }
+    
+    while true
+      page_number += 1
+      query["page[number]"] = page_number
+      path = "/v1/repos/#{repo_id}/snapshots/#{snapshot_id}/issues?#{query.to_query}"
+      response = CodeClimateRequest.new.request(path)
+      files = response_to_data(response, path)
+      break if files.nil?
+      result += files
+    end
+    
+    result
+  end
+
+  def files(repo_id, snapshot_id)
+    result = []
+    page_number = 0
+    query = {
+      "page[size]"   => 100,
+      "page[number]" => page_number
+    }
+    
+    while true
+      page_number += 1
+      query["page[number]"] = page_number
+      path = "/v1/repos/#{repo_id}/snapshots/#{snapshot_id}/files?#{query.to_query}"
+      response = CodeClimateRequest.new.request(path)
+      files = response_to_data(response, path)
+      break if files.nil?
+      result += files
+    end
+    
+    result
+  end
+
+  private
+
+  def response_to_data(response, path = nil)
+    data = nil
+
+    if response.code == "200"
+      parsed_response = JSON.parse(response.body)
+      if parsed_response["data"].size > 0
+        data = parsed_response["data"]
+      else
+        if ENV["DEBUG"] == "1"
+          STDERR.puts "Invalid response for path=\"#{path}\": #{parsed_response.inspect}"
+        end
+      end
+    else
+      STDERR.puts "Invalid response code for path=\"#{path}\": #{response.code}"
+    end
+    
+    data
+  end
+end
+
+ALL_REPO_NAMES = [
+  "ManageIQ/manageiq",
+  "ManageIQ/manageiq-schema",
+  "ManageIQ/manageiq-api",
+  "ManageIQ/manageiq-ui-classic",
+  "ManageIQ/manageiq-ui-service",
+  "ManageIQ/manageiq-automation_engine",
+  "ManageIQ/manageiq-content",
+  "ManageIQ/manageiq-providers-amazon",
+  "ManageIQ/manageiq-providers-ansible_tower",
+  "ManageIQ/manageiq-providers-azure",
+  "ManageIQ/manageiq-providers-azure_stack",
+  "ManageIQ/manageiq-providers-foreman",
+  "ManageIQ/manageiq-providers-google",
+  "ManageIQ/manageiq-providers-kubernetes",
+  "ManageIQ/manageiq-providers-lenovo",
+  "ManageIQ/manageiq-providers-nuage",
+  "ManageIQ/manageiq-providers-openshift",
+  "ManageIQ/manageiq-providers-openstack",
+  "ManageIQ/manageiq-providers-ovirt",
+  "ManageIQ/manageiq-providers-redfish",
+  "ManageIQ/manageiq-providers-scvmm",
+  "ManageIQ/manageiq-providers-vmware",
+]
+
+repo_names = ARGV[0].nil? ? ALL_REPO_NAMES : [ARGV[0]]
+
+repo_names.each do |repo_name|
+  stats = CodeClimate.repo_stats(repo_name)
+  puts "Stats for repo #{repo_name}: #{stats.inspect}"
+end

--- a/code_climate.rb
+++ b/code_climate.rb
@@ -78,27 +78,16 @@ class CodeClimate
   end
 
   def issues(repo_id, snapshot_id)
-    result = []
-    page_number = 0
-    query = {
-      "page[size]"   => 100,
-      "page[number]" => page_number
-    }
-    
-    while true
-      page_number += 1
-      query["page[number]"] = page_number
-      path = "/v1/repos/#{repo_id}/snapshots/#{snapshot_id}/issues?#{query.to_query}"
-      response = CodeClimateRequest.new.request(path)
-      files = response_to_data(response, path)
-      break if files.nil?
-      result += files
-    end
-    
-    result
+    multi_paged_query("/v1/repos/#{repo_id}/snapshots/#{snapshot_id}/issues")
   end
 
   def files(repo_id, snapshot_id)
+    multi_paged_query("/v1/repos/#{repo_id}/snapshots/#{snapshot_id}/files")
+  end
+
+  private
+
+  def multi_paged_query(base_path)
     result = []
     page_number = 0
     query = {
@@ -109,17 +98,15 @@ class CodeClimate
     while true
       page_number += 1
       query["page[number]"] = page_number
-      path = "/v1/repos/#{repo_id}/snapshots/#{snapshot_id}/files?#{query.to_query}"
+      path = "#{base_path}?#{query.to_query}"
       response = CodeClimateRequest.new.request(path)
-      files = response_to_data(response, path)
-      break if files.nil?
-      result += files
+      data = response_to_data(response, path)
+      break if data.nil?
+      result += data
     end
     
     result
   end
-
-  private
 
   def response_to_data(response, path = nil)
     data = nil

--- a/code_climate.rb
+++ b/code_climate.rb
@@ -2,13 +2,12 @@ require "net/http"
 require "json"
 require "active_support/core_ext"
 
-CODECLIMATE_API_TOKEN = "your CodeClimage API token"
-CODECLIMATE_URL       = "https://api.codeclimate.com"
+DEFAULT_CODECLIMATE_URL = "https://api.codeclimate.com"
 
 class CodeClimateRequest
   def initialize
-    @base_uri  = ENV["CODECLIMATE_URL"]       || CODECLIMATE_URL
-    @api_token = ENV["CODECLIMATE_API_TOKEN"] || CODECLIMATE_API_TOKEN
+    @base_uri  = ENV["CODECLIMATE_URL"] || DEFAULT_CODECLIMATE_URL
+    @api_token = ENV.fetch("CODECLIMATE_API_TOKEN")
   end
 
   def request(path)


### PR DESCRIPTION
Sample Output:

```sh
$ ruby code_climate.rb
Stats for Repo ManageIQ/manageiq: {"files"=>1742, "loc"=>83362, "issues"=>{"total"=>1068, "complexity"=>474, "duplication"=>293, "style"=>261, "bug_risk"=>40}, "rating"=>"A"}
Stats for Repo ManageIQ/manageiq-schema: {"files"=>848, "loc"=>17666, "issues"=>{"total"=>280, "complexity"=>68, "duplication"=>183, "style"=>27, "bug_risk"=>2}, "rating"=>"B"}
Stats for Repo ManageIQ/manageiq-api: {"files"=>239, "loc"=>7729, "issues"=>{"total"=>194, "complexity"=>95, "duplication"=>90, "style"=>2, "bug_risk"=>7}, "rating"=>"B"}
Stats for Repo ManageIQ/manageiq-ui-classic: {"files"=>2914, "loc"=>126440, "issues"=>{"total"=>4973, "complexity"=>2422, "duplication"=>976, "style"=>590, "bug_risk"=>219}, "rating"=>"C"}
Stats for Repo ManageIQ/manageiq-ui-service: {"files"=>408, "loc"=>13083, "issues"=>{"total"=>201, "complexity"=>177, "duplication"=>24, "style"=>0, "bug_risk"=>0}, "rating"=>"C"}
Stats for Repo ManageIQ/manageiq-automation_engine: {"files"=>204, "loc"=>8292, "issues"=>{"total"=>179, "complexity"=>147, "duplication"=>23, "style"=>7, "bug_risk"=>2}, "rating"=>"C"}
Stats for Repo ManageIQ/manageiq-content: {"files"=>1548, "loc"=>9210, "issues"=>{"total"=>248, "complexity"=>105, "duplication"=>107, "style"=>31, "bug_risk"=>5}, "rating"=>"C"}
Stats for Repo ManageIQ/manageiq-providers-amazon: {"files"=>125, "loc"=>4693, "issues"=>{"total"=>84, "complexity"=>52, "duplication"=>18, "style"=>13, "bug_risk"=>1}, "rating"=>"B"}
Stats for Repo ManageIQ/manageiq-providers-ansible_tower: {"files"=>75, "loc"=>1792, "issues"=>{"total"=>24, "complexity"=>15, "duplication"=>7, "style"=>1, "bug_risk"=>1}, "rating"=>"A"}
Stats for Repo ManageIQ/manageiq-providers-azure: {"files"=>101, "loc"=>3961, "issues"=>{"total"=>75, "complexity"=>51, "duplication"=>15, "style"=>5, "bug_risk"=>4}, "rating"=>"C"}
Stats for Repo ManageIQ/manageiq-providers-azure_stack: {}
Stats for Repo ManageIQ/manageiq-providers-foreman: {"files"=>56, "loc"=>805, "issues"=>{"total"=>11, "complexity"=>7, "duplication"=>2, "style"=>2, "bug_risk"=>0}, "rating"=>"A"}
Stats for Repo ManageIQ/manageiq-providers-google: {"files"=>84, "loc"=>1650, "issues"=>{"total"=>15, "complexity"=>10, "duplication"=>2, "style"=>3, "bug_risk"=>0}, "rating"=>"A"}
Stats for Repo ManageIQ/manageiq-providers-kubernetes: {"files"=>86, "loc"=>3886, "issues"=>{"total"=>49, "complexity"=>38, "duplication"=>5, "style"=>5, "bug_risk"=>1}, "rating"=>"B"}
Stats for Repo ManageIQ/manageiq-providers-lenovo: {"files"=>113, "loc"=>3671, "issues"=>{"total"=>52, "complexity"=>10, "duplication"=>38, "style"=>4, "bug_risk"=>0}, "rating"=>"A"}
Stats for Repo ManageIQ/manageiq-providers-nuage: {"files"=>83, "loc"=>1600, "issues"=>{"total"=>22, "complexity"=>8, "duplication"=>13, "style"=>1, "bug_risk"=>0}, "rating"=>"B"}
Stats for Repo ManageIQ/manageiq-providers-openshift: {"files"=>62, "loc"=>693, "issues"=>{"total"=>11, "complexity"=>5, "duplication"=>4, "style"=>1, "bug_risk"=>1}, "rating"=>"B"}
Stats for Repo ManageIQ/manageiq-providers-openstack: {"files"=>202, "loc"=>10390, "issues"=>{"total"=>227, "complexity"=>133, "duplication"=>79, "style"=>12, "bug_risk"=>3}, "rating"=>"B"}
Stats for Repo ManageIQ/manageiq-providers-ovirt: {"files"=>126, "loc"=>6621, "issues"=>{"total"=>102, "complexity"=>70, "duplication"=>7, "style"=>25, "bug_risk"=>0}, "rating"=>"B"}
Stats for Repo ManageIQ/manageiq-providers-redfish: {"files"=>69, "loc"=>1286, "issues"=>{"total"=>19, "complexity"=>6, "duplication"=>12, "style"=>1, "bug_risk"=>0}, "rating"=>"B"}
Stats for Repo ManageIQ/manageiq-providers-scvmm: {"files"=>67, "loc"=>1683, "issues"=>{"total"=>25, "complexity"=>14, "duplication"=>4, "style"=>7, "bug_risk"=>0}, "rating"=>"B"}
Stats for Repo ManageIQ/manageiq-providers-vmware: {"files"=>160, "loc"=>7735, "issues"=>{"total"=>208, "complexity"=>153, "duplication"=>26, "style"=>27, "bug_risk"=>2}, "rating"=>"C"}
```
