### PR TITLE
Support included_repos in config file.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,7 @@
 ---
 :github_organization: ManageIQ
 :additional_repos: []
+:included_repos: []
 :excluded_repos:
 - ManageIQ/integration_tests
 - ManageIQ/manageiq-appliance-dev-setup

--- a/merged_prs_per_sprint.rb
+++ b/merged_prs_per_sprint.rb
@@ -46,11 +46,19 @@ class MergedPrs
   end
 
   def excluded_repo?(repo_name)
-    @config[:excluded_repos].include?(repo_name)
+    return true if excluded_repos.include?(repo_name)
+
+    return !included_repos.include?(repo_name) if included_repos.present?
+
+    false
   end
 
   def excluded_repos
     @excluded_repos ||= Array(@config[:excluded_repos])
+  end
+
+  def included_repos
+    @included_repos ||= Array(@config[:included_repos])
   end
 
   def filters_match?(pr)


### PR DESCRIPTION
@jvlcek has a use case for excluding all but a few (or maybe one) repos and uses the `excluded_repos` property to list every repo to skip.  An `included_repos` list would be a more convenient way to achieve the same goal.

This PR adds support for an optional `included_repos` config setting which gets checked during the `excluded_repo?` method.