### PR TITLE
Remove transferred repo name from exclude list

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,6 @@
 - ManageIQ/miq_tools_services
 - ManageIQ/polisher
 - ManageIQ/sprint_statistics
-- ManageIQ/wrapanapi
 :priority:
 - :prefix: E
   :label: enhancement


### PR DESCRIPTION
Remove transferred repo name (`wrapanapi`) from exclude list.