### PR TITLE
Allow the caller to specify start/end and sprint length options.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@ source 'https://rubygems.org'
 plugin "bundler-inject", "~> 1.1"
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
-gem 'activesupport',        "~> 5.0", :require => false
-gem 'more_core_extensions',           :require => false
-gem 'octokit',              "~> 4.3", :require => false
-gem 'parallel',                       :require => false
-gem 'optimist',                       :require => false
+gem 'activesupport',        "~> 5.2.4.3", :require => false
+gem 'more_core_extensions',               :require => false
+gem 'octokit',              "~> 4.3",     :require => false
+gem 'parallel',                           :require => false
+gem 'optimist',                           :require => false

--- a/merged_prs_per_sprint.rb
+++ b/merged_prs_per_sprint.rb
@@ -8,7 +8,7 @@ class MergedPrs
   REPO_LJUST_LENGTH = 50
 
   def initialize(opts)
-    @sprint = Sprint.prompt_for_sprint(3)
+    @sprint = sprint_boundaries(opts)
     exit if @sprint.nil?
 
     @config_file = opts[:config_file]
@@ -219,6 +219,27 @@ class MergedPrs
           :default  => nil,
           :type     => :string,
           :required => false
+
+      opt :start_date,
+          "Query Start Date (format: YYYY-MM-DD)",
+          :short    => "s",
+          :default  => nil,
+          :type     => :string,
+          :required => false
+
+      opt :end_date,
+          "Query End Date   (format: YYYY-MM-DD)",
+          :short    => "e",
+          :default  => nil,
+          :type     => :string,
+          :required => false
+
+      opt :sprint_length,
+          "Sprint Length (weeks)",
+          :short    => "l",
+          :default  => 2,
+          :type     => :integer,
+          :required => false
     end
 
     opts
@@ -226,6 +247,20 @@ class MergedPrs
 
   def self.run(args)
     new(parse(args)).process_repos
+  end
+end
+
+def sprint_boundaries(opts)
+  if opts[:start_date] || opts[:end_date]
+    start_date = Date.parse(opts[:start_date]) if opts[:start_date]
+    end_date   = Date.parse(opts[:end_date])   if opts[:end_date]
+
+    # If only one date is provided set the other based on the sprint length
+    start_date = end_date - opts[:sprint_length].weeks   unless start_date
+    end_date   = start_date + opts[:sprint_length].weeks unless end_date
+    Sprint.new("NA", start_date..end_date)
+  else
+    Sprint.prompt_for_sprint(3)
   end
 end
 


### PR DESCRIPTION
This change allows a user to specific the start and/or end  of the date range on the command line, along with the sprint length.  If only one date is passed the other will be calculated based on the sprint length, which defaults to 2 weeks.

This gives the flexibility to run the query over any period of time.  Seeing that we already have `optimist` as part of the script I thought this change would be easy and useful in some cases.

Note: If you specific they date range this way it will set the sprint number to "NA".

```
ruby merged_prs_per_sprint.rb -h                                   
Usage: ruby merged_prs_per_sprint.rb [opts]
  -c, --config-file=<s>      Config file name (default: config.yaml)
  -o, --output-file=<s>      Output file name
  -s, --start-date=<s>       Query Start Date (format: YYYY-MM-DD)
  -e, --end-date=<s>         Query End Date   (format: YYYY-MM-DD)
  -l, --sprint-length=<i>    Sprint Length (weeks) (default: 2)
  -h, --help                 Show this message
```

Examples:

1. Want to see what happened over the last two sprints
`ruby merged_prs_per_sprint.rb -e 2020-04-27 -l 4`
or
`ruby merged_prs_per_sprint.rb -s 2020-03-20 -e 2020-04-27`

2. Only care about changes in the last week
`ruby merged_prs_per_sprint.rb -s 2020-04-15 -e 2020-04-22`

3. Or maybe the first quarter of year:
`ruby merged_prs_per_sprint.rb -s 2020-01-01 -e 2020-03-31`

Running for the first quarter of 2020 returned:
```
Total merged PRs for Organization ManageIQ: 1356 (unfiltered count)
Sprint Statistics for: "Sprint NA Ending Mar 31, 2020"  (2020-01-01..2020-03-31)
...
Completed in 45.619304
```