### PR TITLE
prs_per_repo should work without human interaction

### DIFF
--- a/sprint.rb
+++ b/sprint.rb
@@ -1,3 +1,4 @@
+require_relative 'sprint_boundary_iterator'
 class Sprint
   def self.prompt_for_sprint(count)
     sprints = recent_sprints(count).reverse
@@ -21,26 +22,10 @@ class Sprint
   end
 
   def self.sprints(as_of: Date.today)
-    require "active_support/core_ext/numeric/time"
-    # The first date when we started doing this cadence
-    number = 76
-    date   = Date.parse("Jan 1, 2018")
-    range  = Date.parse("Dec 12, 2018")..date
+    as_of ||= SprintBoundaryIterator.start_range.end
 
-    as_of ||= date
-
-    Enumerator.new do |y|
-      loop do
-        y << new(number, range) if date >= as_of
-
-        last_date = date
-        number += 1
-        date += 2.weeks
-        while (date.month == 12 && (22..31).cover?(date.day)) || (date.month == 1 && (1..4).cover?(date.day))
-          date += 1.weeks
-        end
-        range = (last_date + 1.day)..date
-      end
+    SprintBoundaryIterator.new.collect do |number, range|
+      new(number, range) if range.end >= as_of
     end
   end
 

--- a/sprint.rb
+++ b/sprint.rb
@@ -21,6 +21,17 @@ class Sprint
     sprints(as_of: nil).slice_after { |s| s.date >= Date.today }.first.last(count)
   end
 
+  def self.last_completed
+    Sprint.recent_sprints(2).first
+  end
+
+  def self.create_by_sprint_number(sprint_number)
+    SprintBoundaryIterator.new.each do |number, range|
+      return new(number, range) if number == sprint_number
+    end
+    nil
+  end
+
   def self.sprints(as_of: Date.today)
     as_of ||= SprintBoundaryIterator.start_range.end
 

--- a/sprint_boundary_iterator.rb
+++ b/sprint_boundary_iterator.rb
@@ -1,0 +1,38 @@
+class SprintBoundaryIterator
+  include Enumerable
+  require "active_support/core_ext/numeric/time"
+
+  def self.start
+    # The first date when we started doing this cadence
+    [76, Date.parse("Dec 12, 2017")..Date.parse("Jan 1, 2018")]
+  end
+
+  def self.start_range
+    start.last
+  end
+
+  def self.start_number
+    start.first
+  end
+
+  def each
+    number, range = self.class.start
+    today = Date.today
+    while today > range.first do
+      yield number, range
+
+      range = next_range(range)
+      number   += 1
+    end
+  end
+
+  private
+
+  def next_range(current)
+    date = current.end + 2.weeks
+    while (date.month == 12 && (22..31).cover?(date.day)) || (date.month == 1 && (1..4).cover?(date.day))
+      date += 1.weeks
+    end
+    current = (current.end + 1.day)..date
+  end
+end


### PR DESCRIPTION
Added ability to specify a sprint on the command line.

`ruby prs_per_repo.rb` will prompt the user to specify a repo
`ruby prs_per_repo.rb -s last` specifies the last completed sprint.
`ruby prs_per_repo.rb -s 131` specifies sprint 131.