### PR TITLE
Fix require in code_climate.rb

### DIFF
--- a/code_climate.rb
+++ b/code_climate.rb
@@ -1,5 +1,6 @@
 require "net/http"
 require "json"
+require "active_support"
 require "active_support/core_ext"
 require "more_core_extensions/core_ext/array/element_counts"
 


### PR DESCRIPTION
Following instructions documented in https://edgeguides.rubyonrails.org/active_support_core_extensions.html#stand-alone-active-support section 1.1.3 Loading All Core Extensions

Without this, got the following:
```
$ ruby code_climate.rb
Traceback (most recent call last):
	2: from code_climate.rb:3:in `<main>'
	1: from /Users/oleg/.rubies/ruby-2.6.6/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
/Users/oleg/.rubies/ruby-2.6.6/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- active_support/core_ext (LoadError)
	17: from code_climate.rb:3:in `<main>'
	16: from /Users/oleg/.rubies/ruby-2.6.6/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:34:in `require'
	15: from /Users/oleg/.rubies/ruby-2.6.6/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:130:in `rescue in require'
	14: from /Users/oleg/.rubies/ruby-2.6.6/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:130:in `require'
	13: from /Users/oleg/.gem/ruby/2.6.6/gems/activesupport-5.2.4.3/lib/active_support/core_ext.rb:3:in `<top (required)>'
	12: from /Users/oleg/.gem/ruby/2.6.6/gems/activesupport-5.2.4.3/lib/active_support/core_ext.rb:3:in `each'
	11: from /Users/oleg/.gem/ruby/2.6.6/gems/activesupport-5.2.4.3/lib/active_support/core_ext.rb:4:in `block in <top (required)>'
	10: from /Users/oleg/.rubies/ruby-2.6.6/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:117:in `require'
	 9: from /Users/oleg/.rubies/ruby-2.6.6/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:117:in `require'
	 8: from /Users/oleg/.gem/ruby/2.6.6/gems/activesupport-5.2.4.3/lib/active_support/core_ext/numeric.rb:6:in `<top (required)>'
	 7: from /Users/oleg/.rubies/ruby-2.6.6/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:65:in `require'
	 6: from /Users/oleg/.rubies/ruby-2.6.6/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:65:in `require'
	 5: from /Users/oleg/.gem/ruby/2.6.6/gems/activesupport-5.2.4.3/lib/active_support/core_ext/numeric/conversions.rb:4:in `<top (required)>'
	 4: from /Users/oleg/.rubies/ruby-2.6.6/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:65:in `require'
	 3: from /Users/oleg/.rubies/ruby-2.6.6/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:65:in `require'
	 2: from /Users/oleg/.gem/ruby/2.6.6/gems/activesupport-5.2.4.3/lib/active_support/number_helper.rb:3:in `<top (required)>'
	 1: from /Users/oleg/.gem/ruby/2.6.6/gems/activesupport-5.2.4.3/lib/active_support/number_helper.rb:4:in `<module:ActiveSupport>'
/Users/oleg/.gem/ruby/2.6.6/gems/activesupport-5.2.4.3/lib/active_support/number_helper.rb:5:in `<module:NumberHelper>': uninitialized constant ActiveSupport::Autoload (NameError)
```