### PR TITLE
Extracted GithubClient from SprintStatistics class

### DIFF
--- a/github_client.rb
+++ b/github_client.rb
@@ -1,4 +1,4 @@
-class OctokitClient
+class GithubClient
   attr_reader :handle
 
   def initialize(access_token)

--- a/octokit_client.rb
+++ b/octokit_client.rb
@@ -1,0 +1,28 @@
+class OctokitClient
+  attr_reader :handle
+
+  def initialize(access_token)
+    require 'octokit'
+    Octokit.configure do |c|
+      c.auto_paginate = true
+      c.middleware = Faraday::RackBuilder.new do |builder|
+        if ENV['DEBUG']
+          builder.use(
+            Class.new(Faraday::Response::Middleware) do
+              def on_complete(env)
+                api_calls_remaining = env.response_headers['x-ratelimit-remaining']
+                STDOUT.puts "DEBUG: Executed #{env.method.to_s.upcase} #{env.url} ... api calls remaining #{api_calls_remaining}"
+              end
+            end
+          )
+        end
+
+        builder.use Octokit::Response::RaiseError
+        builder.use Octokit::Response::FeedParser
+        builder.adapter Faraday.default_adapter
+      end
+    end
+
+    @handle ||= Octokit::Client.new(:access_token => access_token)
+  end
+end

--- a/sprint_statistics.rb
+++ b/sprint_statistics.rb
@@ -1,4 +1,4 @@
-require_relative 'octokit_client'
+require_relative 'github_client'
 require 'active_support'
 require 'active_support/core_ext'
 
@@ -33,7 +33,7 @@ class SprintStatistics
   end
 
   def client
-    @client ||= OctokitClient.new(@github_api_token).handle
+    @client ||= GithubClient.new(@github_api_token).handle
   end
 
   def fetch(collection, *args)


### PR DESCRIPTION
Separation of concerns so that callers can use the Octokit::Client (properly configured and initialized) without having to instantiate SprintStatistics.