### PR TITLE
Add IBM Repos to Code Climate script

### DIFF
--- a/code_climate.rb
+++ b/code_climate.rb
@@ -152,6 +152,8 @@ ALL_REPO_NAMES = [
   "ManageIQ/manageiq-providers-azure_stack",
   "ManageIQ/manageiq-providers-foreman",
   "ManageIQ/manageiq-providers-google",
+  "ManageIQ/manageiq-providers-ibm_cloud",
+  "ManageIQ/manageiq-providers-ibm_terraform",
   "ManageIQ/manageiq-providers-kubernetes",
   "ManageIQ/manageiq-providers-lenovo",
   "ManageIQ/manageiq-providers-nsxt",


### PR DESCRIPTION
This is a tactical fix.  The right approach is to get the list from https://github.com/ManageIQ/manageiq-release/blob/master/config/labels.yml#L172

Are there code examples from non [manageiq-release](https://github.com/ManageIQ/manageiq-release) repos that use this approach?