### PR TITLE
Update to new sprint boundary cadence

### DIFF
--- a/sprint_boundary_iterator.rb
+++ b/sprint_boundary_iterator.rb
@@ -46,9 +46,9 @@ class SprintBoundaryIterator
 
   def compute_next_range(current)
     date = current.end + 2.weeks
-    while (date.month == 12 && (22..31).cover?(date.day)) || (date.month == 1 && (1..4).cover?(date.day))
+    while (date.month == 12 && (21..31).cover?(date.day)) || (date.month == 1 && (1..3).cover?(date.day))
       date += 1.weeks
     end
-    current = (current.end + 1.day)..date
+    (current.end + 1.day)..date
   end
 end


### PR DESCRIPTION
@chessbyte Please review. 

Here's the diff of what this yields before/after:

```diff
diff --git a/before.txt b/after.txt
index b26dc23..587c0e3 100644
--- a/before.txt
+++ b/after.txt
@@ -142,5 +142,5 @@
  "149: 2020-10-27..2020-11-09",
  "150: 2020-11-10..2020-11-23",
  "151: 2020-11-24..2020-12-07",
- "152: 2020-12-08..2020-12-21",
- "153: 2020-12-22..2021-01-11"]
+ "152: 2020-12-08..2021-01-04",
+ "153: 2021-01-05..2021-01-18"]
```