### PR TITLE
Use psych 3.3.2+ for unsafe_load

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 gem 'activesupport',        "~> 5.2.4.3", :require => false
 gem 'more_core_extensions',               :require => false
 gem 'octokit',              "~> 4.3",     :require => false
-gem 'parallel',                           :require => false
 gem 'optimist',                           :require => false
+gem 'parallel',                           :require => false
 gem 'psych',                ">=3.3.2",    :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gem 'more_core_extensions',               :require => false
 gem 'octokit',              "~> 4.3",     :require => false
 gem 'parallel',                           :require => false
 gem 'optimist',                           :require => false
+gem 'psych',                ">=3.3.2",    :require => false


### PR DESCRIPTION
Psych added unsafe_load in 3.3.2+ here:
ruby/psych#488

PR #66 depended on unsafe_load but it doesn't exist in 3.3.1 or earlier.