### PR TITLE
default file output same as script name

### DIFF
--- a/merged_prs_per_sprint.rb
+++ b/merged_prs_per_sprint.rb
@@ -14,7 +14,7 @@ class MergedPrs
     @config_file = opts[:config_file]
     @config = YAML.load_file(@config_file)
 
-    @output_file = opts[:output_file] || "merged_prs_for_sprint_#{@sprint.number}.md"
+    @output_file = opts[:output_file] || "merged_prs_per_sprint_#{@sprint.number}.md"
   end
 
   def github_api_token


### PR DESCRIPTION
I would like to have the script and the default filename be the same
This way tab complete doesn't hit a partial complete

But if people want me to rename the script, we can do that too